### PR TITLE
Fix environment for Windows and include Jupyter

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,23 +1,24 @@
-name: base
+name: antarctic
 channels:
   - conda-forge
   - defaults
 dependencies:
+  - pip
+  - jupyter
   - click=7.1.2=py_0
   - glob2=0.7=py_0
-  - keras=2.3.1=py37_0
-  - keras-applications=1.0.8=py_1
-  - keras-preprocessing=1.1.0=py_0
-  - numpy=1.16.2=py37h7e9f1db_0
-  - numpy-base=1.16.2=py37hde5b4d6_0
+  - keras=2.3.1
+  - keras-applications
+  - keras-preprocessing
+  - numpy=1.16.2
+  - numpy-base=1.16.2
   - numpydoc=0.9.2=py_0
-  - pillow=5.4.1=py37h34e0f95_0
-  - scipy=1.2.1=py37h7c811a0_0
+  - pillow=5.4.1
+  - scipy=1.2.1
   - tensorboard=1.13.1=py37_0
-  - tensorflow=1.13.1=py37h90a7d86_1
+  - tensorflow=1.13.1
   - tensorflow-estimator=1.13.0=py_0
   - pip:
     - matplotlib==3.2.2
     - scikit-learn==0.20.2
-
 


### PR DESCRIPTION
The strict binary version in environment file does not hold on Windows.
It also lacks package for Jupyter.